### PR TITLE
Make functions tail-recursive

### DIFF
--- a/src/Builder/Build.elm
+++ b/src/Builder/Build.elm
@@ -383,7 +383,7 @@ isEquivalent root path oldPath =
       case ( prefix, testPath ) of
         ( [], _ ) -> True
         ( _, [] ) -> False
-        ( prefixHead :: prefixTail, testHead :: testTail ) -> prefixHead == testHead && startsWith prefixTail testTail
+        ( prefixHead :: prefixTail, testHead :: testTail ) -> if prefixHead == testHead then startsWith prefixTail testTail else False
   in
   startsWith (SysFile.getNames (SysFile.makeRelative root path)) (SysFile.getNames oldPath)
 

--- a/src/Extra/System/MVector.elm
+++ b/src/Extra/System/MVector.elm
@@ -87,7 +87,7 @@ replicate n a ( nextId, map, refState ) =
         go : Int -> IORef.IO a (Map Int (IORef a)) -> IORef.IO a (Map Int (IORef a))
         go i vecIO =
             if i < n then
-                go (i + 1) <| IO.liftA2 (Map.insert i) (IORef.new a) vecIO
+                go (i + 1) (IO.liftA2 (Map.insert i) (IORef.new a) vecIO)
 
             else
                 vecIO


### PR DESCRIPTION
As you had announced, I quickly ran into stack overflows when running the repl in Chrome/Firefox.

I used the [`NoUnoptimizedRecursion`](https://package.elm-lang.org/packages/jfmengels/elm-review-performance/latest/NoUnoptimizedRecursion) `elm-review` rule to tell me recursive functions that are not tail-recursive.

Unfortunately, it reports over 430 errors. From a rough look, I think that the code style in the Elm compiler uses Haskell's laziness quite intensively and that doesn't translate well to the eager Elm runtime. I fixed a few, then focused on the parser and unfortunately could not find quick and easy fixes.

I figured I would at least make a PR with what I found in the meantime.